### PR TITLE
Fix: Xref Table Creation and Stream Length Errors

### DIFF
--- a/src/Build/Compiler.php
+++ b/src/Build/Compiler.php
@@ -156,8 +156,12 @@ class Compiler extends AbstractCompiler
         $numObjs       = count($this->objects) + 1;
         $this->trailer = "xref\n0 {$numObjs}\n0000000000 65535 f \n";
 
-        $this->byteLength += $this->calculateByteLength($this->root);
+        // Intial Length is the length of the version string
+        $this->byteLength = 9;
         $this->trailer    .= $this->formatByteLength($this->byteLength) . " 00000 n \n";
+
+        // New Length is the distance to the second object
+        $this->byteLength = $this->calculateByteLength($this->root);
 
         $this->output .= $this->root;
 
@@ -169,15 +173,15 @@ class Compiler extends AbstractCompiler
                     (!$object->isEncoded() && !$object->isImported() && (stripos((string)$object->getDefinition(), '/length') === false))) {
                     $object->encode();
                 }
-                $this->byteLength += $this->calculateByteLength($object);
                 $this->trailer    .= $this->formatByteLength($this->byteLength) . " 00000 n \n";
                 $this->output     .= $object;
+                $this->byteLength += $this->calculateByteLength($object);
             }
         }
 
         // Finalize the trailer.
         $this->trailer .= "trailer\n<</Size {$numObjs}/Root " . $this->root->getIndex() . " 0 R/Info " .
-            $this->info->getIndex() . " 0 R>>\nstartxref\n" . ($this->byteLength + 68) . "\n%%EOF";
+            $this->info->getIndex() . " 0 R>>\nstartxref\n" . ($this->byteLength) . "\n%%EOF";
 
         // Append the trailer to the final output.
         $this->output .= $this->trailer;

--- a/src/Build/PdfObject/StreamObject.php
+++ b/src/Build/PdfObject/StreamObject.php
@@ -294,8 +294,8 @@ class StreamObject extends AbstractObject
      */
     public function __toString()
     {
-        // Set the stream.
-        $stream = (null !== $this->stream) ? "stream" . $this->stream . "endstream\n" : '';
+        // Set the stream, adding linefeed
+        $stream = (null !== $this->stream) ? "stream" . $this->stream . "\nendstream\n" : '';
 
         // Set up the Length definition.
         if ((strpos((string)$this->definition, '/Length ') !== false) && (strpos((string)$this->definition, '/Length1') === false) &&


### PR DESCRIPTION
I used Pop-PDF (at v4.2.1, since my company is currently only on PHP v8.0) to generate some PDFs for printing. I am also using Ghostscript to output these generated PDFs to a printer. When generating a document, I discovered that Ghostscript was throwing errors and wouldn't print the files. The files _would_ render properly in Chrome and Adobe, but Adobe would report that there was an issue with the file. I spent about a day and a half tracking down the issues.

# `xref` Section Errors
The first issue is with the way the xref section is created. This library was missing an entry for the `1 0 obj` Catalog/Pages object. In 
https://github.com/popphp/pop-pdf/blob/0e850dfbe3266eb0eb4de1004ed3c5dddf8e3b49/src/Build/Compiler.php#L158, this top object is included in the `$this->root` property. I just hard coded the initial entry in, since it should remain static (the length of the PDF version string + linefeed).

```
xref
0 12
0000000000 65535 f 
0000000009 00000 n   <-- This was missing
0000000054 00000 n 
0000000105 00000 n 
0000000285 00000 n 
0000000415 00000 n 
```

The second issue is that the offsets were to the END of each object, not the start of the object. I changed the order of operations which fixed that.

The third, related issue was that the `startxref` value was wrong. You had some magical number 68 in there which I assume was intended to compensate for something, but it needed to be calculated from the sums properly, which it does now with the above change.

# Stream Length Issues
Once I resolved the `xref` issues, I was also getting some errors about Stream Length being wrong. I tracked this back to the `__toString` method in the https://github.com/onedaydoors/pop-pdf/blob/ab52a91af2dae18dbcd5c796d062f5bd72d3f6b6/src/Build/PdfObject/StreamObject.php#L298 file. The exact stream length was actually one byte too long. This appears to be related to the way the stream is terminated. Adding a linefeed in front of the to the `endstream` seems to have resolved the issue in all the places I was able to see.

It looks like you can likely port these changes up to your 5.x branch, since I don't think you made changes in the calculations but I can only submit a PR against the 4.x branch, since that's what I'm using.

There is still a lingering error that I was unable to fix. Ghostscript reports: `missing white space after number` when rendering the file. I couldn't figure out what that was all about.

I will say, I really appreciate this library - it has really helped me generate my PDF documents.